### PR TITLE
Closes #363 assert_true checks not correct. After discussion the whole method for…

### DIFF
--- a/R/mcmc.R
+++ b/R/mcmc.R
@@ -257,7 +257,7 @@ setMethod(
                  from_prior = data@nObs == 0L,
                  ...) {
     if (!from_prior) {
-      assert_true(length(model@skel_probs) == max(data@nGrid))
+      assert_true(length(model@skel_probs) == data@nGrid)
     }
 
     callNextMethod(

--- a/R/mcmc.R
+++ b/R/mcmc.R
@@ -235,8 +235,8 @@ setMethod(
 
 #' @describeIn mcmc Standard method which uses JAGS. For the
 #'   [`OneParExpNormalPrior`] model, it is required that the length of
-#'   skeleton prior probabilities vector should be equal to the maximum dose
-#'   level observed in data.
+#'   skeleton prior probabilities vector should be equal to the length of the
+#'   number of doses.
 #'
 #' @param from_prior (`flag`)\cr sample from the prior only? Default to `TRUE`
 #'   when number of observations in `data` is `0`. For some models it might be
@@ -257,7 +257,7 @@ setMethod(
                  from_prior = data@nObs == 0L,
                  ...) {
     if (!from_prior) {
-      assert_true(length(model@skel_probs) == max(data@xLevel))
+      assert_true(length(model@skel_probs) == max(data@nGrid))
     }
 
     callNextMethod(

--- a/R/mcmc.R
+++ b/R/mcmc.R
@@ -231,44 +231,6 @@ setMethod(
   }
 )
 
-# mcmc-GeneralData-OneParExpNormalPrior ----
-
-#' @describeIn mcmc Standard method which uses JAGS. For the
-#'   [`OneParExpNormalPrior`] model, it is required that the length of
-#'   skeleton prior probabilities vector should be equal to the maximum dose
-#'   level observed in data.
-#'
-#' @param from_prior (`flag`)\cr sample from the prior only? Default to `TRUE`
-#'   when number of observations in `data` is `0`. For some models it might be
-#'   necessary to specify it manually here though.
-#'
-#' @aliases mcmc-GeneralData-OneParExpNormalPrior
-#'
-setMethod(
-  f = "mcmc",
-  signature = signature(
-    data = "GeneralData",
-    model = "OneParExpNormalPrior",
-    options = "McmcOptions"
-  ),
-  def = function(data,
-                 model,
-                 options,
-                 from_prior = data@nObs == 0L,
-                 ...) {
-    if (!from_prior) {
-      assert_true(length(model@skel_probs) == max(data@xLevel))
-    }
-
-    callNextMethod(
-      data = data,
-      model = model,
-      options = options,
-      from_prior = from_prior,
-      ...
-    )
-  }
-)
 
 # nolint start
 

--- a/R/mcmc.R
+++ b/R/mcmc.R
@@ -231,6 +231,44 @@ setMethod(
   }
 )
 
+# mcmc-GeneralData-OneParExpNormalPrior ----
+
+#' @describeIn mcmc Standard method which uses JAGS. For the
+#'   [`OneParExpNormalPrior`] model, it is required that the length of
+#'   skeleton prior probabilities vector should be equal to the maximum dose
+#'   level observed in data.
+#'
+#' @param from_prior (`flag`)\cr sample from the prior only? Default to `TRUE`
+#'   when number of observations in `data` is `0`. For some models it might be
+#'   necessary to specify it manually here though.
+#'
+#' @aliases mcmc-GeneralData-OneParExpNormalPrior
+#'
+setMethod(
+  f = "mcmc",
+  signature = signature(
+    data = "GeneralData",
+    model = "OneParExpNormalPrior",
+    options = "McmcOptions"
+  ),
+  def = function(data,
+                 model,
+                 options,
+                 from_prior = data@nObs == 0L,
+                 ...) {
+    if (!from_prior) {
+      assert_true(length(model@skel_probs) == max(data@xLevel))
+    }
+
+    callNextMethod(
+      data = data,
+      model = model,
+      options = options,
+      from_prior = from_prior,
+      ...
+    )
+  }
+)
 
 # nolint start
 


### PR DESCRIPTION
closes #363 

… OneParExpNormalPrior can be removed as not needed.

Tested with simulation. Works without the method in mcmc.