### PR TITLE
Test fixes - adding handling for empty expression `x[i, ]` edge case

### DIFF
--- a/R/helpers_covr.R
+++ b/R/helpers_covr.R
@@ -54,6 +54,8 @@ h_covr_detrace <- function(expr) {
   }
 
   detrace <- function(x) {
+    # returns "missing" expression to avoid errors with calls
+    if (x == bquote()) return(x)
     x <- h_covr_detrace_call(x)
     if (is.call(x)) x[-1] <- lapply(x[-1], h_covr_detrace)
     x

--- a/R/helpers_covr.R
+++ b/R/helpers_covr.R
@@ -55,7 +55,9 @@ h_covr_detrace <- function(expr) {
 
   detrace <- function(x) {
     # returns "missing" expression to avoid errors with calls
-    if (x == bquote()) return(x)
+    if (x == bquote()) {
+      return(x)
+    }
     x <- h_covr_detrace_call(x)
     if (is.call(x)) x[-1] <- lapply(x[-1], h_covr_detrace)
     x

--- a/R/helpers_covr.R
+++ b/R/helpers_covr.R
@@ -55,9 +55,10 @@ h_covr_detrace <- function(expr) {
 
   detrace <- function(x) {
     # returns "missing" expression to avoid errors with calls
-    if (x == bquote()) {
+    if (identical(x, bquote())) {
       return(x)
     }
+
     x <- h_covr_detrace_call(x)
     if (is.call(x)) x[-1] <- lapply(x[-1], h_covr_detrace)
     x

--- a/tests/testthat/test-helpers_covr.R
+++ b/tests/testthat/test-helpers_covr.R
@@ -59,6 +59,20 @@ test_that("h_covr_detrace removes all covr traces", {
     expr
   )
 
+  # case when an argument is missing, as in `x[i, ]`
+  expr <- quote(if (TRUE) {
+    covr:::count("file.R:1:2:3:4:5:6:7:8")
+    1 + 2 + if (TRUE) {
+      covr:::count("file.R:11:12:13:14:15:16:17:18")
+      x[i, ]
+    }
+  })
+
+  expect_equal(
+    withr::with_envvar(c(R_COVR = "true"), h_covr_detrace(expr)),
+    quote(1 + 2 + x[i, ])
+  )
+
   expr <- quote(function(x) {
     if (TRUE) {
       covr:::count("file.R:1:2:3:4:5:6:7:8")


### PR DESCRIPTION
# Pull Request

To address test failures specifically when `covr` is used, this updates the way traces are stripped from model specification code so that snippets with an empty expression (`x[i, ]`) don't trigger the "argument missing with no default" error.

A very curious behavior of R here! 