### PR TITLE
add doc for trueTmax parameter in simulate method

### DIFF
--- a/R/Design-methods.R
+++ b/R/Design-methods.R
@@ -3987,7 +3987,11 @@ setMethod("simulate",
 ##' @param truthSurv a CDF which takes as input a time (vector) and returns
 ##'   the true cumulative probability (vector) that the DLT would occur conditioning on the patient
 ##'   has DLTs.
-##' @param trueTmax add documentation here
+##' @param trueTmax the true maximum time at which the DLT occurs. 
+##'   If not provided, it defaults to the maximum time in the trial data. 
+##'   If `trueTmax` is less than the trial's maximum time, 
+##'   it issues a warning and sets `trueTmax` to the trial's maximum time. 
+##'   Use this parameter to specify the maximum time for toxicity events.
 ##' @param args data frame with arguments for the \code{truth} function. The
 ##'   column names correspond to the argument names, the rows to the values of the
 ##'   arguments. The rows are appropriately recycled in the \code{nsim}

--- a/man/DADesign-class.Rd
+++ b/man/DADesign-class.Rd
@@ -34,7 +34,12 @@ This class has special requirements for the \code{model} and \code{data}
 slots in comparison to the parent class \code{\link{Design}}:
 }
 \details{
-The \code{safetyWindow} slot should be an instance of the \code{SafetyWindow} class, which can be customized to specify the duration of the safety window for your trial. The safety window represents the time period during which the toxicity data is collected and analyzed to make dose escalation decisions.
+The \code{safetyWindow} slot should be an instance of the \code{SafetyWindow} class.
+It can be customized to specify the duration of the safety window for your trial.
+The safety window represents the time period required to observe toxicity data
+from the ongoing cohort before opening the next cohort.
+Note that even after opening the next cohort,
+further toxicity data will be collected and analyzed to make dose escalation decisions.
 
 To specify a constant safety window, use the \code{SafetyWindowConst} constructor. For example:
 

--- a/man/simulate-DADesign-method.Rd
+++ b/man/simulate-DADesign-method.Rd
@@ -38,7 +38,11 @@ arguments can be supplied in \code{args}.}
 the true cumulative probability (vector) that the DLT would occur conditioning on the patient
 has DLTs.}
 
-\item{trueTmax}{add documentation here}
+\item{trueTmax}{the true maximum time at which the DLT occurs.
+If not provided, it defaults to the maximum time in the trial data.
+If \code{trueTmax} is less than the trial's maximum time,
+it issues a warning and sets \code{trueTmax} to the trial's maximum time.
+Use this parameter to specify the maximum time for toxicity events.}
 
 \item{args}{data frame with arguments for the \code{truth} function. The
 column names correspond to the argument names, the rows to the values of the


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #628

@danielinteractive 
There are two issues with this merge request:

1. It includes part of the updates from the last issue (625) I am working on. Because after fixing the lint error in merge request for 625, the automatic merged is done before I update the .Rd files. The issue 625 has been closed and I could not include the update .Rd files in previous issue. Instead I include them in this issue.

2. The description for the parameter `trueTmax` was created based on my understanding of the code in `simulate` method. I need a bit more context to come-up with a more accurate and useful doc. I want to know how user actually use this parameter, will they give it as a constant based on their clinical knowledge and experience? Or in crmPack has other functions to calculate or estimate this value? How was it done? Due to my limited knowledge in this field, it is a bit hard for me to answer these questions. I would like to talk to you if possible.