### PR TITLE
Ensure LogisticLogNormalOrdinal throws error when cov is not diagonal

### DIFF
--- a/R/Model-class.R
+++ b/R/Model-class.R
@@ -3349,7 +3349,8 @@ FractionalCRM <- function(...) {
 #' @export
 .LogisticLogNormalOrdinal <- setClass(
   Class = "LogisticLogNormalOrdinal",
-  contains = "ModelLogNormal"
+  contains = "ModelLogNormal",
+  validity = v_logisticlognormalordinal
 )
 
 ## constructor ----

--- a/R/Model-validity.R
+++ b/R/Model-validity.R
@@ -590,3 +590,17 @@ v_model_one_par_exp_prior <- function(object) {
 
   v$result()
 }
+
+#' @describeIn v_model_objects confirms that cov is diagonal
+v_logisticlognormalordinal <- function(object) {
+  v <- Validate()
+  # diag(x) returns a vector, not a matrix, so cannot use identical(x, diag(x)
+  x <- object@params@cov
+  diag(x) <- rep(0, ncol(x))
+  v$check(
+    all(x == 0),
+    "covariance matrix must be diagonal"
+  )
+  v$result()
+}
+

--- a/tests/testthat/test-Model-validity.R
+++ b/tests/testthat/test-Model-validity.R
@@ -1156,3 +1156,24 @@ test_that("v_model_one_par_exp_prior returns message for wrong lambda", {
   object@lambda <- 1:2
   expect_equal(v_model_one_par_exp_prior(object), err_msg)
 })
+
+# v_logisticlognormalordinal ----
+test_that("LogisticLogNormalOrdinal accepts only diagonal covariance matrices", {
+  expect_no_error(
+    LogisticLogNormalOrdinal(
+      mean = c(3, 4, 0),
+      cov = diag(c(4, 3, 1)),
+      ref_dose = 1
+    )
+  )
+
+  expect_error(
+    LogisticLogNormalOrdinal(
+      mean = c(3, 4, 0),
+      cov = matrix(c(4, -0.1, -0.1, -0.1, 3, -0.1, -0.1, -0.1, 1), ncol = 3),
+      ref_dose = 1
+    ),
+    "invalid class \"LogisticLogNormalOrdinal\" object\\: covariance matrix must be diagonal"
+  )
+
+})


### PR DESCRIPTION
Closes #753
