### PR TITLE
Update check.yaml

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,6 +62,8 @@ jobs:
     uses: insightsengineering/r.pkg.template/.github/workflows/style.yaml@main
     with:
       auto-update: true
+    secrets: 
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
   grammar:
     if: github.event_name == 'pull_request'
     name: Grammar Check 🔤


### PR DESCRIPTION
As suggested by Franciszek Walkowiak in chat:

I think this might be the problem with Style workflow not retriggering the checks because the built-in GitHub token was used to commit the styling changes.

Can you try modifying the call to style workflow (https://github.com/Roche/crmPack/blob/main/.github/workflows/check.yaml#L59-L64), like this (two new lines at the bottom are added).  style:
    if: github.event_name == 'pull_request'
    name: Style Check 👗
    uses: insightsengineering/r.pkg.template/.github/workflows/style.yaml@main
    with:
      auto-update: true
    secrets: 
      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

cc @Dinakar Kulkarni It's related to this I think: https://github.com/insightsengineering/r.pkg.template/pull/216
