### PR TITLE
888 fix negative surv time

### DIFF
--- a/R/Design-methods.R
+++ b/R/Design-methods.R
@@ -4485,7 +4485,7 @@ setMethod(
 
                   ## update DLT free survival time of those already enrolled patients
                   if (length(id_to_deescalate_enrolled) > 0) {
-                    id_to_deescalate_surv_time <- min(
+                    id_to_deescalate_surv_time <- pmin(
                       factSurv[id_to_deescalate_enrolled],
                       this_new_dlt_time - factT0[id_to_deescalate_enrolled]
                     )


### PR DESCRIPTION
closes #888 

The problem is very specific for the situation that `deescalate = TRUE`, i.e. if there are patients in this cohort which are still ongoing in their observation time or not even recruited yet, when a DLT happens in a previous cohort at a lower dose. The previous code did not check whether these patients were recruited yet, and therefore could eventually produce negative survival times. Now this is fixed.