### PR TITLE
669: Design doc for adding backfilling cohorts during study simulations

### DIFF
--- a/design/backfill.qmd
+++ b/design/backfill.qmd
@@ -119,7 +119,7 @@ You can try out the prototype implementation by installing `crmPack` from the fo
 remotes::install_github("openpharma/crmPack", ref = "danielinteractive/prototype669")
 ```
 
-This is a simple example of a simulation with backfilling cohorts:
+This is a simple example of a simulation with backfilling cohorts. Note that you need to use the `crmPack:::` prefix to access the new classes and methods which are not yet exported.
 
 ```{r}
 library(crmPack)


### PR DESCRIPTION
closes #669

To amend in prototype:

Backfill class:

- [x] `total_size`
- [x] `priority`

Stopping class:

- [x] flag for `StoppingPatientsNearDose` (as example)

Opening:

- [x] rework `openCohort` method
- [x] new class `OpeningMinCohorts` (this is sufficient as an example to implement delayed opening of backfill cohorts - e.g. only open when 5 cohorts have been recruited in total)
- [x] add logical operators

simulate method:

- [x] obey total size limit
- [x] Need to check all previously tested dose levels below the current recommended dose whether backfilling is possible
- [x] obey priority
- [x] obey next recommended dose as upper limit 