### PR TITLE
Fix for JAGS 5.0.0

### DIFF
--- a/tests/testthat/test-mcmc.R
+++ b/tests/testthat/test-mcmc.R
@@ -87,7 +87,9 @@ test_that("JAGS model compile works as expected for an example model", {
     "Resolving undeclared variables",
     "Allocating nodes",
     "Graph information:",
-    "Observed stochastic nodes: 24",
+    ifelse(rjags::jags.version() >= numeric_version("5.0.0"),
+           "Fully observed stochastic nodes: 24",
+           "Observed stochastic nodes: 24"),
     "Unobserved stochastic nodes: 26",
     "Total graph size: 196",
     ""


### PR DESCRIPTION
# Pull Request

In advance of the release of JAGS 5.0.0 I am testing the reverse dependencies of the rjags package on CRAN. For crmPack everything is fine but one of your tests fails due to a change in output.

JAGS 5.0.0 permits partly observed nodes. The node count when a model is compiled now only counts fully observed nodes and the text has changed from "Observed nodes" to "Fully observed nodes". I have included a workaround in the test that works with both the released version of JAGS and future version 5.0.0.