### PR TITLE
934: `MinimalInformative` and `Quantiles2LogisticNormal` now also support producing `LogisticLogNormalSub` models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Version 2.1.0.9000
 
+### New Features
+
+* Combination designs are supported via `DesignCombo` and `HierarchicalDesign`. Please see the new vignette `combo_designs` for details.
+* `MinimalInformative` and `Quantiles2LogisticNormal` now also support producing `LogisticLogNormalSub` models, i.e. using the subtraction of a reference dose on the natural dose scale in the regression model.
+
 ### Bugfixes
 
 * The `knit_print` method for `LogisticNormalMixture` did not render correctly previously; this is fixed now.

--- a/R/fromQuantiles.R
+++ b/R/fromQuantiles.R
@@ -200,12 +200,14 @@ Quantiles2LogisticNormal <- function(
   # Argument validation
   assert_numeric(
     dosegrid,
-    min.len = 1,
+    min.len = 2, # Need length 2 otherwise the slope calculation fails.
     any.missing = FALSE,
     sorted = TRUE,
     unique = TRUE
   )
+  assert_true(all(dosegrid > 0))
   assert_number(refDose, finite = TRUE)
+  assert_true(refDose > 0)
   assert_numeric(lower, len = length(dosegrid), any.missing = FALSE)
   assert_numeric(
     median,
@@ -406,6 +408,8 @@ MinimalInformative <- function(
     unique = TRUE
   )
   assert_number(refDose, finite = TRUE)
+  assert_true(all(dosegrid > 0))
+  assert_true(refDose > 0)
   assert_probability(threshmin, bounds_closed = FALSE)
   assert_probability(threshmax, bounds_closed = FALSE)
   assert_probability(probmin, bounds_closed = FALSE)

--- a/R/fromQuantiles.R
+++ b/R/fromQuantiles.R
@@ -368,8 +368,8 @@ h_get_min_inf_beta <- function(p, q) {
 #' [`LogisticLogNormal`] or [`LogisticLogNormalSub`]) model. Note that the reference dose
 #' is not required for these computations.
 #'
-#' @param dosegrid (`numeric`)\cr the dose grid.
-#' @param refDose (`number`)\cr the reference dose.
+#' @param dosegrid (`numeric`)\cr the dose grid, only positive sorted values are allowed.
+#' @param refDose (`number`)\cr the reference dose. Must be positive if `useLogDose = TRUE`.
 #' @param threshmin (`number`)\cr any toxicity probability above this threshold
 #'   would be very unlikely (see `probmin`) at the minimum dose.
 #' @param threshmax (`number`)\cr any toxicity probability below this threshold

--- a/R/fromQuantiles.R
+++ b/R/fromQuantiles.R
@@ -230,6 +230,9 @@ Quantiles2LogisticNormal <- function(
   assert_true(all(parlower < parupper))
   if (!useLogDose) {
     assert_true(logNormal)
+  } else {
+    assert_true(all(dosegrid > 0))
+    assert_true(refDose > 0)
   }
   if (!is.null(parstart)) {
     assert_true(all(parlower < parstart))

--- a/R/fromQuantiles.R
+++ b/R/fromQuantiles.R
@@ -11,6 +11,7 @@ NULL
 #' @param dosegrid (`numeric`)\cr dose grid.
 #' @param refDose (`number`)\cr reference dose.
 #' @param logNormal (`flag`)\cr use log-normal prior?
+#' @param useLogDose (`flag`)\cr use `log(dosegrid / refDose)` as dose covariate?
 #'
 #' @return Numeric vector of starting values.
 #' @keywords internal
@@ -19,11 +20,17 @@ h_get_quantiles_start_values <- function(
   median,
   dosegrid,
   refDose,
-  logNormal
+  logNormal,
+  useLogDose = TRUE
 ) {
   if (is.null(parstart)) {
     # Find approximate means for alpha and slope beta from fitting logistic model to medians.
-    startAlphaBeta <- coef(lm(I(logit(median)) ~ I(log(dosegrid / refDose))))
+    doseCovariate <- if (useLogDose) {
+      log(dosegrid / refDose)
+    } else {
+      dosegrid - refDose
+    }
+    startAlphaBeta <- coef(lm(I(logit(median)) ~ I(doseCovariate)))
 
     c(
       meanAlpha = unname(startAlphaBeta[1]),
@@ -48,6 +55,7 @@ h_get_quantiles_start_values <- function(
 #' @param upper (`numeric`)\cr upper quantiles.
 #' @param level (`number`)\cr credible level.
 #' @param logNormal (`flag`)\cr use log-normal prior?
+#' @param useLogDose (`flag`)\cr use `log(dosegrid / refDose)` as dose covariate?
 #' @param seed (`count`)\cr random seed.
 #'
 #' @return Function that computes target value for optimization.
@@ -60,8 +68,15 @@ h_quantiles_target_function <- function(
   upper,
   level,
   logNormal,
-  seed
+  seed,
+  useLogDose = TRUE
 ) {
+  doseCovariate <- if (useLogDose) {
+    log(dosegrid / refDose)
+  } else {
+    dosegrid - refDose
+  }
+
   function(param) {
     # Form the mean vector and covariance matrix
     mean <- param[1:2]
@@ -103,7 +118,7 @@ h_quantiles_target_function <- function(
     for (i in seq_along(dosegrid)) {
       # Create samples of the probability
       probSamples <- plogis(
-        alphaSamples + betaSamples * log(dosegrid[i] / refDose)
+        alphaSamples + betaSamples * doseCovariate[i]
       )
 
       # Compute lower, median and upper quantile
@@ -138,6 +153,9 @@ h_quantiles_target_function <- function(
 #'   Default is 0.95.
 #' @param logNormal (`flag`)\cr use the log-normal prior? If `FALSE` (default),
 #'   the normal prior for the logistic regression coefficients is used.
+#' @param useLogDose (`flag`)\cr use `log(dosegrid / refDose)` as dose covariate?
+#'   If `FALSE`, `logNormal` must be `TRUE` and a [`LogisticLogNormalSub`]
+#'   model is returned.
 #' @param parstart (`numeric` or `NULL`)\cr starting values for the parameters.
 #'   By default, these are determined from the medians supplied.
 #' @param parlower (`numeric`)\cr lower bounds on the parameters (intercept alpha
@@ -149,7 +167,8 @@ h_quantiles_target_function <- function(
 #'   see [GenSA::GenSA()] for more details.
 #'
 #' @return A list with the best approximating `model`
-#'   ([`LogisticNormal`] or [`LogisticLogNormal`]), the resulting `quantiles`,
+#'   ([`LogisticNormal`], [`LogisticLogNormal`], or [`LogisticLogNormalSub`]),
+#'   the resulting `quantiles`,
 #'   the `required` quantiles and the `distance` to the required quantiles,
 #'   as well as the final `parameters` (which could be used for running the
 #'   algorithm a second time).
@@ -175,7 +194,8 @@ Quantiles2LogisticNormal <- function(
     maxit = 50000,
     temperature = 50000,
     max.time = 600
-  )
+  ),
+  useLogDose = TRUE
 ) {
   # Argument validation
   assert_numeric(
@@ -196,6 +216,7 @@ Quantiles2LogisticNormal <- function(
   assert_numeric(upper, len = length(dosegrid), any.missing = FALSE)
   assert_probability(level, bounds_closed = FALSE)
   assert_flag(logNormal)
+  assert_flag(useLogDose)
   assert_numeric(parstart, len = 5, null.ok = TRUE)
   assert_numeric(parlower, len = 5, any.missing = FALSE)
   assert_numeric(parupper, len = 5, any.missing = FALSE)
@@ -207,6 +228,9 @@ Quantiles2LogisticNormal <- function(
   assert_true(all(lower < median))
   assert_true(all(median < upper))
   assert_true(all(parlower < parupper))
+  if (!useLogDose) {
+    assert_true(logNormal)
+  }
   if (!is.null(parstart)) {
     assert_true(all(parlower < parstart))
     assert_true(all(parstart < parupper))
@@ -220,7 +244,8 @@ Quantiles2LogisticNormal <- function(
     median = median,
     dosegrid = dosegrid,
     refDose = refDose,
-    logNormal = logNormal
+    logNormal = logNormal,
+    useLogDose = useLogDose
   )
 
   target <- h_quantiles_target_function(
@@ -231,6 +256,7 @@ Quantiles2LogisticNormal <- function(
     upper = upper,
     level = level,
     logNormal = logNormal,
+    useLogDose = useLogDose,
     seed = seed
   )
 
@@ -248,8 +274,14 @@ Quantiles2LogisticNormal <- function(
   targetRes <- target(pars)
 
   # Construct the model
-  model <- if (logNormal) {
+  model <- if (logNormal && useLogDose) {
     LogisticLogNormal(
+      mean = attr(targetRes, "mean"),
+      cov = attr(targetRes, "cov"),
+      ref_dose = refDose
+    )
+  } else if (logNormal && !useLogDose) {
+    LogisticLogNormalSub(
       mean = attr(targetRes, "mean"),
       cov = attr(targetRes, "cov"),
       ref_dose = refDose
@@ -325,10 +357,11 @@ h_get_min_inf_beta <- function(p, q) {
 #' controlled with the arguments `probmin` and `probmax`, respectively.
 #' Subsequently, for all doses supplied in the
 #' `dosegrid` argument, beta distributions are set up from the assumption
-#' that the prior medians are linear in log-dose on the logit scale, and
+#' that the prior medians are linear in log-dose (or dose if
+#' `useLogDose = FALSE`) on the logit scale, and
 #' [Quantiles2LogisticNormal()] is used to transform the resulting
 #' quantiles into an approximating [`LogisticNormal`] (or
-#' [`LogisticLogNormal`]) model. Note that the reference dose
+#' [`LogisticLogNormal`] or [`LogisticLogNormalSub`]) model. Note that the reference dose
 #' is not required for these computations.
 #'
 #' @param dosegrid (`numeric`)\cr the dose grid.
@@ -341,6 +374,9 @@ h_get_min_inf_beta <- function(p, q) {
 #'   at the minimum dose.
 #' @param probmax (`number`)\cr the prior probability of being below `threshmax`
 #'   at the maximum dose.
+#' @param useLogDose (`flag`)\cr use `log(dosegrid / refDose)` as dose covariate?
+#'   If `FALSE`, pass `logNormal = TRUE` via `...` to obtain a
+#'   [`LogisticLogNormalSub`] model.
 #' @param ... additional arguments for computations, see
 #'   [Quantiles2LogisticNormal()], e.g. `refDose` and
 #'   `logNormal=TRUE` to obtain a minimal informative log normal prior.
@@ -358,7 +394,8 @@ MinimalInformative <- function(
   threshmax = 0.3,
   probmin = 0.05,
   probmax = 0.05,
-  ...
+  ...,
+  useLogDose = TRUE
 ) {
   # Argument validation
   assert_numeric(
@@ -373,10 +410,9 @@ MinimalInformative <- function(
   assert_probability(threshmax, bounds_closed = FALSE)
   assert_probability(probmin, bounds_closed = FALSE)
   assert_probability(probmax, bounds_closed = FALSE)
+  assert_flag(useLogDose)
 
   nDoses <- length(dosegrid)
-  xmin <- dosegrid[1]
-  xmax <- dosegrid[nDoses]
 
   # Derive the beta distributions at the lowest and highest dose
   betaAtMin <- h_get_min_inf_beta(
@@ -393,9 +429,15 @@ MinimalInformative <- function(
   medianMax <- with(betaAtMax, qbeta(p = 0.5, a, b))
 
   # Determine the medians of all beta distributions
-  beta <- (logit(medianMax) - logit(medianMin)) / (log(xmax) - log(xmin))
-  alpha <- logit(medianMax) - beta * log(xmax / refDose)
-  medianDosegrid <- plogis(alpha + beta * log(dosegrid / refDose))
+  doseCovariate <- if (useLogDose) {
+    log(dosegrid / refDose)
+  } else {
+    dosegrid - refDose
+  }
+  beta <- (logit(medianMax) - logit(medianMin)) /
+    (doseCovariate[nDoses] - doseCovariate[1L])
+  alpha <- logit(medianMax) - beta * doseCovariate[nDoses]
+  medianDosegrid <- plogis(alpha + beta * doseCovariate)
 
   # Calculate 95% credible interval bounds (lower and upper) for all doses
   lower <- upper <- dosegrid
@@ -419,6 +461,7 @@ MinimalInformative <- function(
     median = medianDosegrid,
     upper = upper,
     level = 0.95,
+    useLogDose = useLogDose,
     ...
   )
 }

--- a/R/fromQuantiles.R
+++ b/R/fromQuantiles.R
@@ -207,7 +207,6 @@ Quantiles2LogisticNormal <- function(
   )
   assert_true(all(dosegrid > 0))
   assert_number(refDose, finite = TRUE)
-  assert_true(refDose > 0)
   assert_numeric(lower, len = length(dosegrid), any.missing = FALSE)
   assert_numeric(
     median,
@@ -412,7 +411,6 @@ MinimalInformative <- function(
   )
   assert_number(refDose, finite = TRUE)
   assert_true(all(dosegrid > 0))
-  assert_true(refDose > 0)
   assert_probability(threshmin, bounds_closed = FALSE)
   assert_probability(threshmax, bounds_closed = FALSE)
   assert_probability(probmin, bounds_closed = FALSE)
@@ -437,6 +435,7 @@ MinimalInformative <- function(
 
   # Determine the medians of all beta distributions
   doseCovariate <- if (useLogDose) {
+    assert_true(refDose > 0)
     log(dosegrid / refDose)
   } else {
     dosegrid - refDose

--- a/man/MinimalInformative.Rd
+++ b/man/MinimalInformative.Rd
@@ -16,9 +16,9 @@ MinimalInformative(
 )
 }
 \arguments{
-\item{dosegrid}{(\code{numeric})\cr the dose grid.}
+\item{dosegrid}{(\code{numeric})\cr the dose grid, only positive sorted values are allowed.}
 
-\item{refDose}{(\code{number})\cr the reference dose.}
+\item{refDose}{(\code{number})\cr the reference dose. Must be positive if \code{useLogDose = TRUE}.}
 
 \item{threshmin}{(\code{number})\cr any toxicity probability above this threshold
 would be very unlikely (see \code{probmin}) at the minimum dose.}

--- a/man/MinimalInformative.Rd
+++ b/man/MinimalInformative.Rd
@@ -11,7 +11,8 @@ MinimalInformative(
   threshmax = 0.3,
   probmin = 0.05,
   probmax = 0.05,
-  ...
+  ...,
+  useLogDose = TRUE
 )
 }
 \arguments{
@@ -34,6 +35,10 @@ at the maximum dose.}
 \item{...}{additional arguments for computations, see
 \code{\link[=Quantiles2LogisticNormal]{Quantiles2LogisticNormal()}}, e.g. \code{refDose} and
 \code{logNormal=TRUE} to obtain a minimal informative log normal prior.}
+
+\item{useLogDose}{(\code{flag})\cr use \code{log(dosegrid / refDose)} as dose covariate?
+If \code{FALSE}, pass \code{logNormal = TRUE} via \code{...} to obtain a
+\code{\link{LogisticLogNormalSub}} model.}
 }
 \value{
 See \code{\link[=Quantiles2LogisticNormal]{Quantiles2LogisticNormal()}}.
@@ -58,10 +63,11 @@ probability of DLT smaller than \eqn{q_{J}} has only 5\% probability
 controlled with the arguments \code{probmin} and \code{probmax}, respectively.
 Subsequently, for all doses supplied in the
 \code{dosegrid} argument, beta distributions are set up from the assumption
-that the prior medians are linear in log-dose on the logit scale, and
+that the prior medians are linear in log-dose (or dose if
+\code{useLogDose = FALSE}) on the logit scale, and
 \code{\link[=Quantiles2LogisticNormal]{Quantiles2LogisticNormal()}} is used to transform the resulting
 quantiles into an approximating \code{\link{LogisticNormal}} (or
-\code{\link{LogisticLogNormal}}) model. Note that the reference dose
+\code{\link{LogisticLogNormal}} or \code{\link{LogisticLogNormalSub}}) model. Note that the reference dose
 is not required for these computations.
 }
 \examples{

--- a/man/Quantiles2LogisticNormal.Rd
+++ b/man/Quantiles2LogisticNormal.Rd
@@ -18,7 +18,8 @@ Quantiles2LogisticNormal(
   seed = 12345,
   verbose = TRUE,
   control = list(threshold.stop = 0.01, maxit = 50000, temperature = 50000, max.time =
-    600)
+    600),
+  useLogDose = TRUE
 )
 }
 \arguments{
@@ -52,10 +53,15 @@ and the slope beta, the corresponding standard deviations and the correlation).}
 
 \item{control}{(\code{list})\cr additional options for the optimisation routine,
 see \code{\link[GenSA:GenSA]{GenSA::GenSA()}} for more details.}
+
+\item{useLogDose}{(\code{flag})\cr use \code{log(dosegrid / refDose)} as dose covariate?
+If \code{FALSE}, \code{logNormal} must be \code{TRUE} and a \code{\link{LogisticLogNormalSub}}
+model is returned.}
 }
 \value{
 A list with the best approximating \code{model}
-(\code{\link{LogisticNormal}} or \code{\link{LogisticLogNormal}}), the resulting \code{quantiles},
+(\code{\link{LogisticNormal}}, \code{\link{LogisticLogNormal}}, or \code{\link{LogisticLogNormalSub}}),
+the resulting \code{quantiles},
 the \code{required} quantiles and the \code{distance} to the required quantiles,
 as well as the final \code{parameters} (which could be used for running the
 algorithm a second time).

--- a/man/h_get_quantiles_start_values.Rd
+++ b/man/h_get_quantiles_start_values.Rd
@@ -4,7 +4,14 @@
 \alias{h_get_quantiles_start_values}
 \title{Get Starting Values for Quantiles Optimization}
 \usage{
-h_get_quantiles_start_values(parstart, median, dosegrid, refDose, logNormal)
+h_get_quantiles_start_values(
+  parstart,
+  median,
+  dosegrid,
+  refDose,
+  logNormal,
+  useLogDose = TRUE
+)
 }
 \arguments{
 \item{parstart}{(\code{numeric} or \code{NULL})\cr starting parameter values.}
@@ -16,6 +23,8 @@ h_get_quantiles_start_values(parstart, median, dosegrid, refDose, logNormal)
 \item{refDose}{(\code{number})\cr reference dose.}
 
 \item{logNormal}{(\code{flag})\cr use log-normal prior?}
+
+\item{useLogDose}{(\code{flag})\cr use \code{log(dosegrid / refDose)} as dose covariate?}
 }
 \value{
 Numeric vector of starting values.

--- a/man/h_quantiles_target_function.Rd
+++ b/man/h_quantiles_target_function.Rd
@@ -12,7 +12,8 @@ h_quantiles_target_function(
   upper,
   level,
   logNormal,
-  seed
+  seed,
+  useLogDose = TRUE
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ h_quantiles_target_function(
 \item{logNormal}{(\code{flag})\cr use log-normal prior?}
 
 \item{seed}{(\code{count})\cr random seed.}
+
+\item{useLogDose}{(\code{flag})\cr use \code{log(dosegrid / refDose)} as dose covariate?}
 }
 \value{
 Function that computes target value for optimization.

--- a/tests/testthat/test-fromQuantiles.R
+++ b/tests/testthat/test-fromQuantiles.R
@@ -329,8 +329,8 @@ test_that("MinimalInformative works with logNormal = TRUE", {
 test_that("MinimalInformative works with useLogDose = FALSE", {
   skip_on_cran_but_not_ci()
 
-  dosegrid <- c(1, 3, 5)
-  refDose <- 3
+  dosegrid <- c(1, 3, 5, 8)
+  refDose <- 0
 
   result <- MinimalInformative(
     dosegrid = dosegrid,

--- a/tests/testthat/test-fromQuantiles.R
+++ b/tests/testthat/test-fromQuantiles.R
@@ -65,6 +65,30 @@ test_that("h_get_quantiles_start_values works with logNormal = TRUE", {
   expect_equal(result, expected, tolerance = 1e-4)
 })
 
+test_that("h_get_quantiles_start_values works with useLogDose = FALSE", {
+  dosegrid <- c(1, 3, 5, 10)
+  refDose <- 5
+  median <- c(0.1, 0.2, 0.3, 0.4)
+
+  result <- h_get_quantiles_start_values(
+    parstart = NULL,
+    median = median,
+    dosegrid = dosegrid,
+    refDose = refDose,
+    logNormal = TRUE,
+    useLogDose = FALSE
+  )
+
+  expected <- c(
+    meanAlpha = -1.16256,
+    meanBeta = -1.68182,
+    sdAlpha = 1,
+    sdBeta = 1,
+    correlation = 0
+  )
+  expect_equal(result, expected, tolerance = 1e-4)
+})
+
 test_that("h_get_quantiles_start_values works with provided parstart", {
   parstart <- c(1, 2, 3, 4, 5)
 
@@ -119,6 +143,32 @@ test_that("h_quantiles_target_function returns a function", {
   expect_true(all(c("mean", "cov", "quantiles") %in% names(attributes(result))))
   expect_length(attr(result, "mean"), 2)
   expect_equal(dim(attr(result, "cov")), c(2, 2))
+  expect_equal(dim(attr(result, "quantiles")), c(3, 3))
+})
+
+test_that("h_quantiles_target_function uses subtractive dose when requested", {
+  dosegrid <- c(1, 3, 5)
+  refDose <- 3
+  lower <- c(0.05, 0.1, 0.15)
+  median <- c(0.1, 0.2, 0.3)
+  upper <- c(0.15, 0.3, 0.45)
+
+  target_fn <- h_quantiles_target_function(
+    dosegrid = dosegrid,
+    refDose = refDose,
+    lower = lower,
+    median = median,
+    upper = upper,
+    level = 0.95,
+    logNormal = TRUE,
+    useLogDose = FALSE,
+    seed = 12345
+  )
+
+  result <- target_fn(c(-2, -3, 1, 0.5, 0))
+
+  expect_type(result, "double")
+  expect_true(result >= 0)
   expect_equal(dim(attr(result, "quantiles")), c(3, 3))
 })
 
@@ -193,6 +243,48 @@ test_that("Quantiles2LogisticNormal works with logNormal = TRUE", {
   expect_s4_class(result$model, "LogisticLogNormal")
 })
 
+test_that("Quantiles2LogisticNormal works with useLogDose = FALSE", {
+  skip_on_cran_but_not_ci()
+
+  dosegrid <- c(1, 3, 5)
+  refDose <- 3
+  lower <- c(0.05, 0.1, 0.15)
+  median <- c(0.1, 0.2, 0.3)
+  upper <- c(0.15, 0.3, 0.45)
+
+  result <- Quantiles2LogisticNormal(
+    dosegrid = dosegrid,
+    refDose = refDose,
+    lower = lower,
+    median = median,
+    upper = upper,
+    logNormal = TRUE,
+    useLogDose = FALSE,
+    seed = 12345,
+    control = list(maxit = 10, max.time = 1)
+  )
+
+  expect_s4_class(result$model, "LogisticLogNormalSub")
+})
+
+test_that("Quantiles2LogisticNormal requires logNormal with useLogDose = FALSE", {
+  dosegrid <- c(1, 3, 5)
+
+  expect_error(
+    Quantiles2LogisticNormal(
+      dosegrid = dosegrid,
+      refDose = 3,
+      lower = c(0.05, 0.1, 0.15),
+      median = c(0.1, 0.2, 0.3),
+      upper = c(0.15, 0.3, 0.45),
+      logNormal = FALSE,
+      useLogDose = FALSE,
+      control = list(maxit = 10, max.time = 1)
+    ),
+    "Must be TRUE"
+  )
+})
+
 # MinimalInformative ----
 
 test_that("MinimalInformative works with basic inputs", {
@@ -232,4 +324,24 @@ test_that("MinimalInformative works with logNormal = TRUE", {
     control = list(maxit = 10, max.time = 1)
   )
   expect_s4_class(result$model, "LogisticLogNormal")
+})
+
+test_that("MinimalInformative works with useLogDose = FALSE", {
+  skip_on_cran_but_not_ci()
+
+  dosegrid <- c(1, 3, 5)
+  refDose <- 3
+
+  result <- MinimalInformative(
+    dosegrid = dosegrid,
+    refDose = refDose,
+    logNormal = TRUE,
+    useLogDose = FALSE,
+    threshmin = 0.1,
+    threshmax = 0.4,
+    probmin = 0.1,
+    probmax = 0.1,
+    control = list(maxit = 10, max.time = 1)
+  )
+  expect_s4_class(result$model, "LogisticLogNormalSub")
 })


### PR DESCRIPTION
closes #934